### PR TITLE
mild refactor of model-related base classes, more model definitions

### DIFF
--- a/rmp/fields.py
+++ b/rmp/fields.py
@@ -1,0 +1,70 @@
+"""
+Customized Django model field subclasses
+"""
+from django.db import models
+from django.db.models import fields
+
+
+class CopyFromFieldMixin(fields.Field):
+    """
+    Mixin to add attrs related to COPY FROM command to model fields.
+    """
+    def __init__(self, *args, **kwargs):
+        self.source_column = kwargs.pop('source_column', None)
+        super().__init__(*args, **kwargs)
+
+    @property
+    def copy_from_name(self):
+        """
+        Return the name of field to use in COPY FROM command.
+        """
+        return self.source_column or self.name
+    
+
+class CopyFromBooleanField(fields.BooleanField, CopyFromFieldMixin):
+    """
+    BooleanField subclass with attrs related to COPY FROM command.
+    """
+    pass
+
+
+class CopyFromCharField(fields.CharField, CopyFromFieldMixin):
+    """
+    CharField subclass with attrs related to COPY FROM command.
+    """
+    pass
+
+
+class CopyFromDecimalField(fields.DecimalField, CopyFromFieldMixin):
+    """
+    DecimalField subclass with attrs related to COPY FROM command.
+    """
+    pass
+
+
+class CopyFromIntegerField(fields.IntegerField, CopyFromFieldMixin):
+    """
+    IntegerField subclass with attrs related to COPY FROM command.
+    """
+    pass
+
+
+class CopyFromDateTimeField(fields.DateTimeField, CopyFromFieldMixin):
+    """
+    DateTimeField subclass with attrs related to COPY FROM command.
+    """
+    pass
+
+
+class CopyFromTextField(fields.TextField, CopyFromFieldMixin):
+    """
+    TextField subclass with attrs related to COPY FROM command.
+    """
+    pass
+
+
+class CopyFromForeignKey(models.ForeignKey, CopyFromFieldMixin):
+    """
+    ForeignKey subclass with attrs related to COPY FROM command.
+    """
+    pass

--- a/rmp/management/commands/import.py
+++ b/rmp/management/commands/import.py
@@ -9,31 +9,22 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         # iterate over all the models in the rmp app
         for m in apps.get_app_config('rmp').models.values():
-            # get a list of char field that can't be null, 
+
+            model_name = m._meta.object_name
 
             if self.can_import(m):
+                print("...loading %s" % model_name)
                 # flush the table
                 m.objects.all().delete()
-                in_file_name = '%s.tsv' % m._meta.db_table 
-                in_file_path = os.path.join(settings.RMP_DATA_DIR, in_file_name)
-                insert_count = m.objects.from_csv(
-                    in_file_path, 
-                    delimiter='\t',
-                    force_not_null=self.get_char_fields(m)
-                )
+                # copy from csv file
+                insert_count = m.objects.copy_from_raw_csv()
                 print("%s records inserted" % insert_count)
             else:
-                msg = '%s not attached to CopyManager.' % m._meta.object_name
+                msg = '%s not attached to BaseRMPManager.' % model_name
                 print(msg)
 
     def can_import(self, model):
         """
         Test if a model is importable.
         """
-        return hasattr(model.objects, 'from_csv')
-
-    def get_char_fields(self, model):
-        """
-        Return a list of char field on model.
-        """
-        return [f.name for f in model._meta.get_fields() if not f.null]
+        return hasattr(model.objects, 'copy_from_raw_csv')

--- a/rmp/managers.py
+++ b/rmp/managers.py
@@ -1,0 +1,36 @@
+"""
+Customized Django model manager subclasses.
+"""
+import os
+from django.conf import settings
+from postgres_copy import CopyManager
+
+
+class BaseRMPManager(CopyManager):
+    """
+    Abstract subclass upon which all RMP models are based.
+    """
+    def copy_from_raw_csv(self):
+        """
+        Copy contents of a raw .csv file into model.
+        """
+        model = self.model
+
+        source_file = getattr(
+            model, 'source_file', model._meta.db_table
+        )
+        filename = '%s.csv' % source_file
+        path = os.path.join(settings.RMP_RAW_DATA_DIR, filename)
+
+        options = dict(mapping=model.get_source_column_mapping())
+
+        blank_fields = model.get_blank_field_names()
+        null_fields = model.get_null_field_names()
+
+        if len(blank_fields) > 0:
+            options['force_not_null'] = blank_fields
+
+        if len(null_fields):
+            options['force_null'] = null_fields
+
+        return super().from_csv(path, **options)

--- a/rmp/models/__init__.py
+++ b/rmp/models/__init__.py
@@ -12,7 +12,8 @@ from .processed import (
     ProcNaics,
 )
 from .raw import (
-    Tbls6Accidentchemicals,
+    Tbls6AccidentChemicals,
+    # Tbls6AccidentHistory,
 )
 from .codes import (
     ChemCd,
@@ -53,6 +54,6 @@ __all__ = (
     'SubmitCd',
     'TopoCd',
     'WindCd',
-    'Tbls6Accidentchemicals',
-    'Tbls6Flammablemixturechemicals',
+    'Tbls6AccidentChemicals',
+    # 'Tbls6AccidentHistory'
 )

--- a/rmp/models/base.py
+++ b/rmp/models/base.py
@@ -1,32 +1,20 @@
-import os
-from django.conf import settings
+"""
+Customized Django model subclasses
+"""
 from django.db import models
-from postgres_copy import CopyManager
-
-
-class BaseRMPManager(CopyManager):
-
-    def copy_from_raw_csv(self):
-        model = self.model
-
-        source_table = getattr(
-            model, 'source_file', model._meta.db_table
-        )
-        filename = '%s.csv' % source_table
-        path = os.path.join(settings.RMP_RAW_DATA_DIR, filename)
-
-        options = dict(mapping=model.get_source_column_mapping())
-
-        if model.has_blank_fields:
-            options['force_not_null'] = model.get_blank_field_names()
-
-        # if model.has_null_fields:
-        #     options['force_null'] = model.get_null_field_names()
-
-        return super().from_csv(path, **options)
+from rmp.managers import BaseRMPManager
 
 
 class BaseRMPModel(models.Model):
+    """
+    
+    """
+    @classmethod
+    def get_concrete_fields(cls):
+        """
+        Return a list of fields that are declared on the model.
+        """
+        return [f for f in cls._meta.get_fields() if f.concrete]
 
     @classmethod
     def get_blank_field_names(cls):
@@ -34,7 +22,8 @@ class BaseRMPModel(models.Model):
         Return a list of char field on model.
         """
         return [
-            f.copy_from_name for f in cls._meta.get_fields()
+            getattr(f, 'copy_from_name', f.name)
+            for f in cls.get_concrete_fields()
             if f.blank
         ]
 
@@ -44,23 +33,10 @@ class BaseRMPModel(models.Model):
         Return a list of fields that allow NULL values.
         """
         return [
-            f.copy_from_name for f in cls._meta.get_fields()
+            getattr(f, 'copy_from_name', f.name)
+            for f in cls.get_concrete_fields()
             if f.null
         ]
-
-    @classmethod
-    def has_blank_fields(cls):
-        """
-        Return True if the model has blankable fields
-        """
-        return len(cls.get_blank_field_names()) > 0
-
-    @classmethod
-    def has_null_fields(cls):
-        """
-        Return True if the model has nullable fields
-        """
-        return len(cls.get_null_field_names()) > 0
 
     @classmethod
     def get_source_column_mapping(cls):
@@ -69,8 +45,10 @@ class BaseRMPModel(models.Model):
         """
         mapping = {}
 
-        for f in cls._meta.get_fields():
-            mapping[f.name] = f.source_column or f.name
+        for f in cls.get_concrete_fields():
+            mapping[f.name] = getattr(
+                f, 'copy_from_name', f.name
+            )
 
         return mapping
 
@@ -78,43 +56,3 @@ class BaseRMPModel(models.Model):
 
     class Meta:
         abstract = True  
-
-
-class CopyFromBooleanField(models.fields.BooleanField):
-    def __init__(self, *args, **kwargs):
-        self.source_column = kwargs.pop('source_column', None)
-        super().__init__(*args, **kwargs)
-
-    @property
-    def copy_from_name(self):
-        return self.source_column or self.name
-
-
-class CopyFromCharField(models.fields.CharField):
-    def __init__(self, *args, **kwargs):
-        self.source_column = kwargs.pop('source_column', None)
-        super().__init__(*args, **kwargs)
-
-    @property
-    def copy_from_name(self):
-        return self.source_column or self.name
-
-
-class CopyFromDecimalField(models.fields.DecimalField):
-    def __init__(self, *args, **kwargs):
-        self.source_column = kwargs.pop('source_column', None)
-        super().__init__(*args, **kwargs)
-
-    @property
-    def copy_from_name(self):
-        return self.source_column or self.name
-
-
-class CopyFromIntegerField(models.fields.IntegerField):
-    def __init__(self, *args, **kwargs):
-        self.source_column = kwargs.pop('source_column', None)
-        super().__init__(*args, **kwargs)
-
-    @property
-    def copy_from_name(self):
-        return self.source_column or self.name

--- a/rmp/models/codes.py
+++ b/rmp/models/codes.py
@@ -2,14 +2,13 @@
 Code-related RMP data models.
 """
 from django.db import models
-from postgres_copy import CopyManager
-from .base import (
-    BaseRMPModel,
+from rmp.fields import (
     CopyFromBooleanField,
     CopyFromCharField,
     CopyFromDecimalField,
     CopyFromIntegerField,
 )
+from .base import BaseRMPModel
 from .choices import (
     CHEMICAL_TYPE_CHOICES,
 )
@@ -61,9 +60,6 @@ class ChemCd(BaseRMPModel):
 
     source_file = 'tlkpChemicals'
 
-    class Meta:
-        db_table = 'rmp_chem_cd'
-
 
 class DeregCd(models.Model):
     """
@@ -78,8 +74,7 @@ class DeregCd(models.Model):
         help_text='Full description of the de-regulation reason.'
     )
 
-    class Meta:
-        db_table = 'rmp_dereg_cd'
+    source_file = 'rmp_dereg_cd'
 
 
 class DochanCd(models.Model):
@@ -91,10 +86,7 @@ class DochanCd(models.Model):
         max_length=1,
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_dochan_cd'
+    source_file = 'rmp_dochan_cd'
 
 
 class DoctypCd(models.Model):
@@ -111,10 +103,7 @@ class DoctypCd(models.Model):
         help_text='Full description of the document type.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_doctyp_cd'
+    source_file = 'rmp_doctyp_cd'
 
 
 class EventsCd(models.Model):
@@ -131,10 +120,7 @@ class EventsCd(models.Model):
         help_text='Full description of the event type.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_events_cd'
+    source_file = 'rmp_events_cd'
 
 
 class LldescCd(models.Model):
@@ -146,10 +132,7 @@ class LldescCd(models.Model):
         max_length=36,
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_lldesc_cd'
+    source_file = 'rmp_lldesc_cd'
 
 
 class LlmethCd(models.Model):
@@ -163,10 +146,7 @@ class LlmethCd(models.Model):
         max_length=83
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_llmeth_cd'
+    source_file = 'rmp_llmeth_cd'
 
 
 class PhysCd(models.Model):
@@ -183,10 +163,7 @@ class PhysCd(models.Model):
         help_text='Full description of the physical state.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_phys_cd'
+    source_file = 'rmp_phys_cd'
 
 
 class RejectCd(models.Model):
@@ -203,10 +180,7 @@ class RejectCd(models.Model):
         help_text='Full description of the rejection reason.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_reject_cd'
+    source_file = 'rmp_reject_cd'
 
 
 class ScenCd(models.Model):
@@ -223,10 +197,7 @@ class ScenCd(models.Model):
         help_text='Full description of the scenario.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_scen_cd'
+    source_file = 'rmp_scen_cd'
 
 
 class SubmitCd(models.Model):
@@ -243,10 +214,7 @@ class SubmitCd(models.Model):
         help_text='Full description of the submission reason.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_submit_cd'
+    source_file = 'rmp_submit_cd'
 
 
 class TopoCd(models.Model):
@@ -263,20 +231,12 @@ class TopoCd(models.Model):
         help_text='Full description of the topography type.'
     )
 
-    objects = CopyManager()
 
-    class Meta:
-        db_table = 'rmp_topo_cd'
-
-class rmp_cities(models.Model):
-    city = models.CharField(max_length=30, blank=True, null=True)
-    state = models.CharField(max_length=2, blank=True, null=True)
+class Cities(models.Model):
+    city = models.CharField(max_length=30, blank=True)
+    state = models.CharField(max_length=2, blank=True)
     num_fac = models.IntegerField()
 
-    objects = CopyManager()
-
-    class Meta:
-         db_table = 'rmp_topo_cd'
 
 class WindCd(models.Model):
     """
@@ -292,7 +252,4 @@ class WindCd(models.Model):
         help_text='Full description of the wind speed measurement unit.'
     )
 
-    objects = CopyManager()
-
-    class Meta:
-        db_table = 'rmp_wind_cd'
+    source_file = 'rmp_wind_cd'

--- a/rmp/models/raw.py
+++ b/rmp/models/raw.py
@@ -6,7 +6,15 @@
 #   * Remove `managed = False` lines if you wish to allow Django to create, modify, and delete the table
 # Feel free to rename the models, but don't rename db_table values or field names.
 from django.db import models
-from postgres_copy import CopyManager
+from .base import BaseRMPModel
+from rmp.fields import (
+    CopyFromBooleanField,
+    CopyFromCharField,
+    CopyFromDecimalField,
+    CopyFromDateTimeField,
+    CopyFromIntegerField,
+    CopyFromForeignKey,
+)
 
 # class Tblexecutivesummaries(models.Model):
 #     esseqnum = models.DecimalField(db_column='ESSeqNum', max_digits=65535, decimal_places=65535)  # Field name made lowercase.
@@ -178,22 +186,30 @@ from postgres_copy import CopyManager
 #         db_table = 'tblS5FlammablesAltReleases'
 
 
-class Tbls6Accidentchemicals(models.Model):
-    accidentchemicalid = models.IntegerField(
+class Tbls6AccidentChemicals(BaseRMPModel):
+    accidentchemicalid = CopyFromIntegerField(
+        source_column='AccidentChemicalID',
         primary_key=True,
         verbose_name='Accident Chemical Record ID',
         help_text='A unique ID for each accident chemical record.',
     )
-    # TODO: ForeignKeyField candidate
-    accidenthistoryid = models.IntegerField(
+    # accidenthistoryid = CopyFromForeignKey(
+    #     'Tbls6Accidenthistory',
+    #     on_delete=models.PROTECT,
+    accidenthistoryid = CopyFromIntegerField(
+        source_column='AccidentHistoryID',
         help_text='The unique ID for each accident record',
     )
     # TODO: ForeignKeyField candidate
-    chemicalid = models.IntegerField(
+    chemicalid = CopyFromForeignKey(
+        'ChemCd',
+        on_delete=models.PROTECT,
+        source_column='ChemicalID',
         help_text='The identifying ID for a particular chemical released in an '
                   'accident.',
     )
-    quantityreleased = models.DecimalField(
+    quantityreleased = CopyFromDecimalField(
+        source_column='QuantityReleased',
         decimal_places=1,
         max_digits=8,
         null=True,
@@ -201,8 +217,8 @@ class Tbls6Accidentchemicals(models.Model):
         help_text='The amount of the substance released in the accident, in '
                   'pounds, to two significant digits.',
     )
-    # TODO: db_fields.tsv says this should be a float field, will decimal work?
-    percentweight = models.DecimalField(
+    percentweight = CopyFromDecimalField(
+        source_column='PercentWeight',
         decimal_places=2,
         null=True,
         max_digits=5,
@@ -211,86 +227,235 @@ class Tbls6Accidentchemicals(models.Model):
                   'in an accident.',
     )
 
-    objects = CopyManager()
-
     class Meta:
         db_table = 'tblS6AccidentChemicals'
 
 
-# class Tbls6Accidenthistory(models.Model):
-#     accidenthistoryid = models.DecimalField(db_column='AccidentHistoryID', max_digits=65535, decimal_places=65535)  # Field name made lowercase.
-#     facilityid = models.DecimalField(db_column='FacilityID', max_digits=65535, decimal_places=65535)  # Field name made lowercase.
-#     accidentdate = models.DateTimeField(db_column='AccidentDate', blank=True, null=True)  # Field name made lowercase.
-#     accidenttime = models.DecimalField(db_column='AccidentTime', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     naicscode = models.DecimalField(db_column='NAICSCode', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     accidentreleaseduration = models.DecimalField(db_column='AccidentReleaseDuration', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     re_gas = models.BooleanField(db_column='RE_Gas')  # Field name made lowercase.
-#     re_spill = models.BooleanField(db_column='RE_Spill')  # Field name made lowercase.
-#     re_fire = models.BooleanField(db_column='RE_Fire')  # Field name made lowercase.
-#     re_explosion = models.BooleanField(db_column='RE_Explosion')  # Field name made lowercase.
-#     re_reactiveincident = models.BooleanField(db_column='RE_ReactiveIncident')  # Field name made lowercase.
-#     rs_storagevessel = models.BooleanField(db_column='RS_StorageVessel')  # Field name made lowercase.
-#     rs_piping = models.BooleanField(db_column='RS_Piping')  # Field name made lowercase.
-#     rs_processvessel = models.BooleanField(db_column='RS_ProcessVessel')  # Field name made lowercase.
-#     rs_transferhose = models.BooleanField(db_column='RS_TransferHose')  # Field name made lowercase.
-#     rs_valve = models.BooleanField(db_column='RS_Valve')  # Field name made lowercase.
-#     rs_pump = models.BooleanField(db_column='RS_Pump')  # Field name made lowercase.
-#     rs_joint = models.BooleanField(db_column='RS_Joint')  # Field name made lowercase.
-#     otherreleasesource = models.CharField(db_column='OtherReleaseSource', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     windspeed = models.DecimalField(db_column='WindSpeed', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     windspeedunitcode = models.CharField(db_column='WindSpeedUnitCode', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     winddirection = models.CharField(db_column='WindDirection', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     temperature = models.DecimalField(db_column='Temperature', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     stabilityclass = models.CharField(db_column='StabilityClass', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     precipitation = models.BooleanField(db_column='Precipitation')  # Field name made lowercase.
-#     weatherunknown = models.BooleanField(db_column='WeatherUnknown')  # Field name made lowercase.
-#     deathsworkers = models.DecimalField(db_column='DeathsWorkers', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     deathspublicresponders = models.DecimalField(db_column='DeathsPublicResponders', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     deathspublic = models.DecimalField(db_column='DeathsPublic', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     injuriesworkers = models.DecimalField(db_column='InjuriesWorkers', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     injuriespublicresponders = models.DecimalField(db_column='InjuriesPublicResponders', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     injuriespublic = models.DecimalField(db_column='InjuriesPublic', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     onsitepropertydamage = models.DecimalField(db_column='OnsitePropertyDamage', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     offsitedeaths = models.BooleanField(db_column='OffsiteDeaths', blank=True, null=True)  # Field name made lowercase.
-#     hospitalization = models.DecimalField(db_column='Hospitalization', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     medicaltreatment = models.DecimalField(db_column='MedicalTreatment', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     evacuated = models.DecimalField(db_column='Evacuated', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     shelteredinplace = models.DecimalField(db_column='ShelteredInPlace', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     offsitepropertydamage = models.DecimalField(db_column='OffsitePropertyDamage', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     ed_kills = models.BooleanField(db_column='ED_Kills')  # Field name made lowercase.
-#     ed_minordefoliation = models.BooleanField(db_column='ED_MinorDefoliation')  # Field name made lowercase.
-#     ed_watercontamination = models.BooleanField(db_column='ED_WaterContamination')  # Field name made lowercase.
-#     ed_soilcontamination = models.BooleanField(db_column='ED_SoilContamination')  # Field name made lowercase.
-#     ed_other = models.CharField(db_column='ED_Other', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     initiatingevent = models.CharField(db_column='InitiatingEvent', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     cf_equipmentfailure = models.BooleanField(db_column='CF_EquipmentFailure')  # Field name made lowercase.
-#     cf_humanerror = models.BooleanField(db_column='CF_HumanError')  # Field name made lowercase.
-#     cf_improperprocedure = models.BooleanField(db_column='CF_ImproperProcedure')  # Field name made lowercase.
-#     cf_overpressurization = models.BooleanField(db_column='CF_Overpressurization')  # Field name made lowercase.
-#     cf_upsetcondition = models.BooleanField(db_column='CF_UpsetCondition')  # Field name made lowercase.
-#     cf_bypasscondition = models.BooleanField(db_column='CF_BypassCondition')  # Field name made lowercase.
-#     cf_maintenance = models.BooleanField(db_column='CF_Maintenance')  # Field name made lowercase.
-#     cf_processdesignfailure = models.BooleanField(db_column='CF_ProcessDesignFailure')  # Field name made lowercase.
-#     cf_unsuitableequipment = models.BooleanField(db_column='CF_UnsuitableEquipment')  # Field name made lowercase.
-#     cf_unusualweather = models.BooleanField(db_column='CF_UnusualWeather')  # Field name made lowercase.
-#     cf_managementerror = models.BooleanField(db_column='CF_ManagementError')  # Field name made lowercase.
-#     cf_other = models.CharField(db_column='CF_Other', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     offsiterespondersnotify = models.CharField(db_column='OffsiteRespondersNotify', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     ci_improvedequipment = models.BooleanField(db_column='CI_ImprovedEquipment')  # Field name made lowercase.
-#     ci_revisedmaintenance = models.BooleanField(db_column='CI_RevisedMaintenance')  # Field name made lowercase.
-#     ci_revisedtraining = models.BooleanField(db_column='CI_RevisedTraining')  # Field name made lowercase.
-#     ci_revisedopprocedures = models.BooleanField(db_column='CI_RevisedOpProcedures')  # Field name made lowercase.
-#     ci_newprocesscontrols = models.BooleanField(db_column='CI_NewProcessControls')  # Field name made lowercase.
-#     ci_newmitigationsystems = models.BooleanField(db_column='CI_NewMitigationSystems')  # Field name made lowercase.
-#     ci_revisederplan = models.BooleanField(db_column='CI_RevisedERPlan')  # Field name made lowercase.
-#     ci_changedprocess = models.BooleanField(db_column='CI_ChangedProcess')  # Field name made lowercase.
-#     ci_reducedinventory = models.BooleanField(db_column='CI_ReducedInventory')  # Field name made lowercase.
-#     ci_none = models.BooleanField(db_column='CI_None')  # Field name made lowercase.
-#     ci_othertype = models.CharField(db_column='CI_OtherType', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     cbi_flag = models.BooleanField(db_column='CBI_Flag')  # Field name made lowercase.
+# class Tbls6AccidentHistory(BaseRMPModel):
+#     accident_id = CopyFromIntegerField(
+#         primary_key=True,
+#         source_column='AccidentHistoryID'
+#     )
+#     # ForeignKey candidate
+#     rmp_id = CopyFromIntegerField(
+#         source_column='FacilityID',
+#     )
+#     accidentdate = CopyFromDateTimeField(
+#         source_column='AccidentDate',
+#         blank=True,
+#         null=True
+#     )
+#     accidenttime = CopyFromCharField(
+#         source_column='AccidentTime',
+#         max_length=4
+#     )
+#     naicscode = CopyFromCharField(
+#         source_column='NAICSCode',
+#         max_length=6
+#     )
+#     accidentreleaseduration = CopyFromCharField(
+#         source_column='AccidentReleaseDuration',
+#         max_length=5)
+#     re_gas = CopyFromBooleanField(
+#         source_column='RE_Gas',
+#     )
+#     re_spill = CopyFromBooleanField(
+#         source_column='RE_Spill',
+#     )
+#     re_fire = CopyFromBooleanField(
+#         source_column='RE_Fire',
+#     )
+#     re_explosion = CopyFromBooleanField(
+#         source_column='RE_Explosion',
+#     )
+#     re_reactiveincident = CopyFromBooleanField(
+#         source_column='RE_ReactiveIncident',
+#     )
+#     rs_storagevessel = CopyFromBooleanField(
+#         source_column='RS_StorageVessel',
+#     )
+#     rs_piping = CopyFromBooleanField(
+#         source_column='RS_Piping',
+#     )
+#     rs_processvessel = CopyFromBooleanField(
+#         source_column='RS_ProcessVessel',
+#     )
+#     rs_transferhose = CopyFromBooleanField(
+#         source_column='RS_TransferHose',
+#     )
+#     rs_valve = CopyFromBooleanField(
+#         source_column='RS_Valve',
+#     )
+#     rs_pump = CopyFromBooleanField(
+#         source_column='RS_Pump',
+#     )
+#     rs_joint = CopyFromBooleanField(
+#         source_column='RS_Joint',
+#     )
+#     otherreleasesource = CopyFromCharField(
+#         source_column='OtherReleaseSource',
+#         max_length=200,
+#         blank=True
+#     )
+#     windspeed = CopyFromDecimalField(
+#         source_column='WindSpeed',
+#         max_digits=6, decimal_places=2, blank=True, null=True
+#     )
+#     windspeedunitcode = CopyFromCharField(
+#         source_column='WindSpeedUnitCode',
+#         max_length=1, blank=True)
+#     winddirection = CopyFromCharField(
+#         source_column='WindDirection',
+#         max_length=3, blank=True)
+#     temperature = CopyFromDecimalField(
+#         source_column='Temperature',
+#         max_digits=6, decimal_places=2)
+#     stabilityclass = CopyFromCharField(
+#         source_column='StabilityClass',
+#         max_length=1, blank=True)
+#     precipitation = CopyFromBooleanField(
+#         source_column='Precipitation',
+#     )
+#     weatherunknown = CopyFromBooleanField(
+#         source_column='WeatherUnknown',
+#     )
+#     deathsworkers = CopyFromIntegerField(
+#         source_column='DeathsWorkers',
+#     )
+#     deathspublicresponders = CopyFromIntegerField(
+#         source_column='DeathsPublicResponders',
+#     )
+#     deathspublic = CopyFromIntegerField(
+#         source_column='DeathsPublic',
+#     )
+#     injuriesworkers = CopyFromIntegerField(
+#         source_column='InjuriesWorkers',
+#     )
+#     injuriespublicresponders = CopyFromIntegerField(
+#         source_column='InjuriesPublicResponders',
+#     )
+#     injuriespublic = CopyFromIntegerField(
+#         source_column='InjuriesPublic',
+#     )
+#     onsitepropertydamage = CopyFromIntegerField(
+#         source_column='OnsitePropertyDamage',
+#     )
+#     offsitedeaths = CopyFromBooleanField(
+#         source_column='OffsiteDeaths',
+#         blank=True, null=True)
+#     hospitalization = CopyFromIntegerField(
+#         source_column='Hospitalization',
+#     )
+#     medicaltreatment = CopyFromIntegerField(
+#         source_column='MedicalTreatment',
+#     )
+#     evacuated = CopyFromIntegerField(
+#         source_column='Evacuated',
+#     )
+#     shelteredinplace = CopyFromIntegerField(
+#         source_column='ShelteredInPlace',
+#     )
+#     offsitepropertydamage = CopyFromIntegerField(
+#         source_column='OffsitePropertyDamage',
+#     )
+#     ed_kills = CopyFromBooleanField(
+#         source_column='ED_Kills',
+#     )
+#     ed_minordefoliation = CopyFromBooleanField(
+#         source_column='ED_MinorDefoliation',
+#     )
+#     ed_watercontamination = CopyFromBooleanField(
+#         source_column='ED_WaterContamination',
+#     )
+#     ed_soilcontamination = CopyFromBooleanField(
+#         source_column='ED_SoilContamination',
+#     )
+#     ed_other = CopyFromCharField(
+#         source_column='ED_Other',
+#         max_length=200, blank=True)
+#     initiatingevent = CopyFromCharField(
+#         source_column='InitiatingEvent',
+#         max_length=1, blank=True)
+#     cf_equipmentfailure = CopyFromBooleanField(
+#         source_column='CF_EquipmentFailure',
+#     )
+#     cf_humanerror = CopyFromBooleanField(
+#         source_column='CF_HumanError',
+#     )
+#     cf_improperprocedure = CopyFromBooleanField(
+#         source_column='CF_ImproperProcedure',
+#     )
+#     cf_overpressurization = CopyFromBooleanField(
+#         source_column='CF_Overpressurization',
+#     )
+#     cf_upsetcondition = CopyFromBooleanField(
+#         source_column='CF_UpsetCondition',
+#     )
+#     cf_bypasscondition = CopyFromBooleanField(
+#         source_column='CF_BypassCondition',
+#     )
+#     cf_maintenance = CopyFromBooleanField(
+#         source_column='CF_Maintenance',
+#     )
+#     cf_processdesignfailure = CopyFromBooleanField(
+#         source_column='CF_ProcessDesignFailure',
+#     )
+#     cf_unsuitableequipment = CopyFromBooleanField(
+#         source_column='CF_UnsuitableEquipment',
+#     )
+#     cf_unusualweather = CopyFromBooleanField(
+#         source_column='CF_UnusualWeather',
+#     )
+#     cf_managementerror = CopyFromBooleanField(
+#         source_column='CF_ManagementError',
+#     )
+#     cf_other = CopyFromCharField(
+#         source_column='CF_Other',
+#         max_length=200, blank=True
+#     )
+#     offsiterespondersnotify = CopyFromCharField(
+#         source_column='OffsiteRespondersNotify',
+#         max_length=25, blank=True
+#     )
+#     ci_improvedequipment = CopyFromBooleanField(
+#         source_column='CI_ImprovedEquipment',
+#     )
+#     ci_revisedmaintenance = CopyFromBooleanField(
+#         source_column='CI_RevisedMaintenance',
+#     )
+#     ci_revisedtraining = CopyFromBooleanField(
+#         source_column='CI_RevisedTraining',
+#     )
+#     ci_revisedopprocedures = CopyFromBooleanField(
+#         source_column='CI_RevisedOpProcedures',
+#     )
+#     ci_newprocesscontrols = CopyFromBooleanField(
+#         source_column='CI_NewProcessControls',
+#     )
+#     ci_newmitigationsystems = CopyFromBooleanField(
+#         source_column='CI_NewMitigationSystems',
+#     )
+#     ci_revisederplan = CopyFromBooleanField(
+#         source_column='CI_RevisedERPlan',
+#     )
+#     ci_changedprocess = CopyFromBooleanField(
+#         source_column='CI_ChangedProcess',
+#     )
+#     ci_reducedinventory = CopyFromBooleanField(
+#         source_column='CI_ReducedInventory',
+#     )
+#     ci_none = CopyFromBooleanField(
+#         source_column='CI_None',
+#     )
+#     ci_othertype = CopyFromCharField(
+#         source_column='CI_OtherType',
+#         max_length=200, blank=True
+#     )
+#     cbi_flag = CopyFromBooleanField(
+#         # source_column='CBI_Flag',
+#     )
 
-#     class Meta:
-#         db_table = 'tblS6AccidentHistory'
+#     source_file = 'tblS6AccidentHistory'
 
 
 # class Tbls8Preventionprogram2(models.Model):
@@ -425,17 +590,40 @@ class Tbls6Accidentchemicals(models.Model):
 #         db_table = 'tblS9EmergencyResponses'
 
 
-# class Tlkpchemicals(models.Model):
-#     chemicalid = models.DecimalField(db_column='ChemicalID', max_digits=65535, decimal_places=65535)  # Field name made lowercase.
-#     chemicalname = models.CharField(db_column='ChemicalName', max_length=-1)  # Field name made lowercase.
-#     casnumber = models.CharField(db_column='CASNumber', max_length=-1, blank=True, null=True)  # Field name made lowercase.
-#     threshold = models.DecimalField(db_column='Threshold', max_digits=65535, decimal_places=65535, blank=True, null=True)  # Field name made lowercase.
-#     chemtype = models.BooleanField(db_column='ChemType', blank=True, null=True)  # Field name made lowercase.
-#     flgcbi = models.BooleanField(db_column='flgCBI')  # Field name made lowercase.
-#     chemowner = models.CharField(db_column='ChemOwner', max_length=-1, blank=True, null=True)  # Field name made lowercase.
+# class Tlkpchemicals(BaseRMPModel):
+#     chemicalid = models.IntegerField(
+#         db_column='ChemicalID',
+#     )  # Field name made lowercase.
+#     chemicalname = models.CharField(
+#         db_column='ChemicalName',
+#         max_length=
+#     )  # Field name made lowercase.
+#     casnumber = models.CharField(
+#         db_column='CASNumber',
+#         max_length=,
+#         blank=True,
+#     )  # Field name made lowercase.
+#     threshold = models.DecimalField(
+#         db_column='Threshold',
+#         max_digits=65535,
+#         decimal_places=65535,
+#         blank=True,
+#     )  # Field name made lowercase.
+#     chemtype = models.BooleanField(
+#         db_column='ChemType',
+#         blank=True,
+#     )  # Field name made lowercase.
+#     flgcbi = models.BooleanField(
+#         db_column='flgCBI'
+#     )  # Field name made lowercase.
+#     chemowner = models.CharField(
+#         db_column='ChemOwner',
+#         max_length=-1,
+#         blank=True,
+#     )  # Field name made lowercase.
 
-#     class Meta:
-#         db_table = 'tlkpChemicals'
+#   class Meta:
+#       db_table = 'tlkpChemicals'
 
 
 # class Tlkpderegistrationreason(models.Model):


### PR DESCRIPTION
Sorry for the huge PR, but I was trying to get to the point where I could work on loading the processed `AccChem` model, as we discussed.

As a result, I fixed a lot of errors in `processed.py` in order to be able to do an initial migration. Most of this is probably cruft from `inspectdb`. 

Here are some highlights:

- Adhering to the Django convention for model names
- Avoiding declaring a custom db_table name
- Using `blank=True` for `CharFields`, but not in conjunction with `null=True`.
- When declaring a ForeignKey instance, you can pass in a string of the model's name, rather than the model itself. Thus, you can avoid importing and errors having to deal with the order in which the model classes are set up.

Haven't quite figured out how to write the query for getting the `AccChem` records with the calculated `num_acc_flam` value. There's something I'm not getting about what supposed to go in this field, but I'm in a state even to ask a lucid question right now. We'll try again later.