### PR TITLE
Environment Clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ venv.bak/
 data/
 migrations/
 zappa_settings.json
+static/

--- a/Pipfile
+++ b/Pipfile
@@ -5,10 +5,10 @@ name = "pypi"
 
 [packages]
 django = ">=2.2.0"
-django-environ = "*"
 django-postgres-copy = "*"
 django-storages = "*"
-zappa = {editable = true, ref = "master", git = "https://github.com/Miserlou/Zappa.git"}
+psycopg2 = "<2.8.0"
+zappa = "*"
 
 [dev-packages]
 django-debug-toolbar = "*"
@@ -19,4 +19,4 @@ ipython = "*"
 ipdb = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.7.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4e48f62e51019ca689074f500174fca8689ac05cf50e1fa396ac326f771356bc"
+            "sha256": "93ef40cf103d779db5e253e0e308273d7e554d23275118288cc649e18d4d3804"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.6"
+            "python_version": "3.7.1"
         },
         "sources": [
             {
@@ -71,14 +71,6 @@
             ],
             "index": "pypi",
             "version": "==2.2"
-        },
-        "django-environ": {
-            "hashes": [
-                "sha256:6c9d87660142608f63ec7d5ce5564c49b603ea8ff25da595fd6098f6dc82afde",
-                "sha256:c57b3c11ec1f319d9474e3e5a79134f40174b17c7cc024bbb2fad84646b120c4"
-            ],
-            "index": "pypi",
-            "version": "==0.4.5"
         },
         "django-postgres-copy": {
             "hashes": [
@@ -157,19 +149,39 @@
         },
         "psycopg2": {
             "hashes": [
-                "sha256:2433931723bf6be4bd342e003ffa9a1cef2cb4de7735d5b063fd554fd64a744c",
-                "sha256:2a0497c8ade1a5a0dc3d62b7f1a4fbcbccfa15d9ef69cce064119cd723566392",
-                "sha256:3ad3cf4732ff7d87dc12031836e5097fc42be767193771da90b8b5038cdca412",
-                "sha256:453c5bc0563c9b9601ef9243c095da9e327f24da6917b7c3ede8e0cd9dd9477d",
-                "sha256:49c5838d90e83217909db3789d30a105385b5e696ec5168cda645546c542f35a",
-                "sha256:6d849117337afd1aa0a74ab9a6c9d2160228d25d5babfa4d9a98bf4a4dad8062",
-                "sha256:8980dbabfb2ed0866b6bd5687d1407c3bccaac1f2f496f1206472108be69b92d",
-                "sha256:a286480430af972be9c30333c48883890dc8d87eab0d591e24975dcf99abff6c",
-                "sha256:bc7ec9ab1f33edd5db40edfb407aabdc92e573c4fcacd9093a9a6f3dd93c7af2",
-                "sha256:d303d9f88ec839a51b430bbec0f4a8314d0d2a53f760e67e95e25e39f6d6fb5f",
-                "sha256:e9836455931ac3d91b71312fa3bb2b9db8c42720a53b7de7db082406e4828585"
+                "sha256:02445ebbb3a11a3fe8202c413d5e6faf38bb75b4e336203ee144ca2c46529f94",
+                "sha256:0e9873e60f98f0c52339abf8f0339d1e22bfe5aae0bcf7aabd40c055175035ec",
+                "sha256:1148a5eb29073280bf9057c7fc45468592c1bb75a28f6df1591adb93c8cb63d0",
+                "sha256:259a8324e109d4922b0fcd046e223e289830e2568d6f4132a3702439e5fd532b",
+                "sha256:28dffa9ed4595429e61bacac41d3f9671bb613d1442ff43bcbec63d4f73ed5e8",
+                "sha256:314a74302d4737a3865d40ea50e430ce1543c921ba10f39d562e807cfe2edf2a",
+                "sha256:36b60201b6d215d7658a71493fdf6bd5e60ad9a0cffed39906627ff9f4f3afd3",
+                "sha256:3f9d532bce54c4234161176ff3b8688ff337575ca441ea27597e112dfcd0ee0c",
+                "sha256:5d222983847b40af989ad96c07fc3f07e47925e463baa5de716be8f805b41d9b",
+                "sha256:6757a6d2fc58f7d8f5d471ad180a0bd7b4dd3c7d681f051504fbea7ae29c8d6f",
+                "sha256:6a0e0f1e74edb0ab57d89680e59e7bfefad2bfbdf7c80eb38304d897d43674bb",
+                "sha256:6ca703ccdf734e886a1cf53eb702261110f6a8b0ed74bcad15f1399f74d3f189",
+                "sha256:8513b953d8f443c446aa79a4cc8a898bd415fc5e29349054f03a7d696d495542",
+                "sha256:9262a5ce2038570cb81b4d6413720484cb1bc52c064b2f36228d735b1f98b794",
+                "sha256:97441f851d862a0c844d981cbee7ee62566c322ebb3d68f86d66aa99d483985b",
+                "sha256:a07feade155eb8e69b54dd6774cf6acf2d936660c61d8123b8b6b1f9247b67d6",
+                "sha256:a9b9c02c91b1e3ec1f1886b2d0a90a0ea07cc529cb7e6e472b556bc20ce658f3",
+                "sha256:ae88216f94728d691b945983140bf40d51a1ff6c7fe57def93949bf9339ed54a",
+                "sha256:b360ffd17659491f1a6ad7c928350e229c7b7bd83a2b922b6ee541245c7a776f",
+                "sha256:b4221957ceccf14b2abdabef42d806e791350be10e21b260d7c9ce49012cc19e",
+                "sha256:b90758e49d5e6b152a460d10b92f8a6ccf318fcc0ee814dcf53f3a6fc5328789",
+                "sha256:c669ea986190ed05fb289d0c100cc88064351f2b85177cbfd3564c4f4847d18c",
+                "sha256:d1b61999d15c79cf7f4f7cc9021477aef35277fc52452cf50fd13b713c84424d",
+                "sha256:de7bb043d1adaaf46e38d47e7a5f703bb3dab01376111e522b07d25e1a79c1e1",
+                "sha256:e393568e288d884b94d263f2669215197840d097c7e5b0acd1a51c1ea7d1aba8",
+                "sha256:ed7e0849337bd37d89f2c2b0216a0de863399ee5d363d31b1e5330a99044737b",
+                "sha256:f153f71c3164665d269a5d03c7fa76ba675c7a8de9dc09a4e2c2cdc9936a7b41",
+                "sha256:f1fb5a8427af099beb7f65093cbdb52e021b8e6dbdfaf020402a623f4181baf5",
+                "sha256:f36b333e9f86a2fba960c72b90c34be6ca71819e300f7b1fc3d2b0f0b2c546cd",
+                "sha256:f4526d078aedd5187d0508aa5f9a01eae6a48a470ed678406da94b4cd6524b7e"
             ],
-            "version": "==2.8"
+            "index": "pypi",
+            "version": "==2.7.7"
         },
         "python-dateutil": {
             "hashes": [
@@ -293,9 +305,13 @@
             "version": "==0.4.6"
         },
         "zappa": {
-            "editable": true,
-            "git": "https://github.com/Miserlou/Zappa.git",
-            "ref": "3ccf7490a8d8b8fa74a61ee39bf44234f3567739"
+            "hashes": [
+                "sha256:621209ceaf2cf5fcc18ed6bb6cf53aeb2315e38989a6929cbb49c66b5454d656",
+                "sha256:86b125c0e9696b177f61bf636ab19ead7aba1bb9281cdba0651825358337008e",
+                "sha256:b7a04172407cdb9277cb166b42920d3c5d745fd50204d1ce7f42769e61b6649e"
+            ],
+            "index": "pypi",
+            "version": "==0.48.2"
         }
     },
     "develop": {
@@ -455,11 +471,11 @@
         },
         "pexpect": {
             "hashes": [
-                "sha256:2a8e88259839571d1251d278476f3eec5db26deb73a70be5ed5dc5435e418aba",
-                "sha256:3fbd41d4caf27fa4a377bfd16fef87271099463e6fa73e92a52f92dfee5d425b"
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
             ],
             "markers": "sys_platform != 'win32'",
-            "version": "==4.6.0"
+            "version": "==4.7.0"
         },
         "pickleshare": {
             "hashes": [

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -17,7 +17,7 @@ INSTALLED_APPS = INSTALLED_APPS + ['debug_toolbar',]
 
 MIDDLEWARE = MIDDLEWARE + [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
-]   
+]
 
 RMP_DATA_DIR = os.path.join(ROOT_DIR, 'data', 'rmp')
 RMP_RAW_DATA_DIR = os.path.join(RMP_DATA_DIR, 'raw')

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -5,7 +5,7 @@ from .base import * # noqa
 
 
 ALLOWED_HOSTS = [
-    'ek4a6i88v6.execute-api.us-east-2.amazonaws.com',
+    '.execute-api.us-east-2.amazonaws.com',
     'rmp.rjifuture.org',
 ]
 


### PR DESCRIPTION
After all that scrambling, the culprit was indeed psycopg2. Seems like zappa had been using a local cached "manylinux" version of psycopg2 2.7.7 until I nuked my virtualenv and downloaded 2.8.1, which I guess includes the needed external libraries. Honestly, I've read a little bit about this, and I'm still trying to figure it out.

Anyway, Adding `psycopg2 = "<2.8.0"` to `Pipfile` did the trick.

There are a few other environment related changes in this PR, including dropping some dependencies we aren't actually using and upgrading to Python 3.7.1. Kinda surprised that went off without a hitch, but I haven't encountered any trouble.

Current deployment is available at <https://lj772t4tvc.execute-api.us-east-2.amazonaws.com/dev>

Emailed you a link to download the latest `zappa_settings.json` file with all the added exclude stuff. Current zip file size is 18.8 MB, which is pretty lean.

I suggest:

1. Merging this PR.
2. Pull down the latest from master.
3. Download the latest `zappa_settings.json` file, add it to your project directory.
4. Do `pipenv --rm` and rm `Pipfile.lock` to nuke your old virtualenv.
5. Run `zappa package dev` and see how big your zip file is.
6. If it's bigger than 18.8, crack it open, and see if there's anything that shouldn't be in there.
7. If need be, add it to the `exclude` node of `zappa_settings.json`, and send me an updated copy.
8. Or just move it out of your project directory.
